### PR TITLE
[STUDIO-4397] Database Connector query fails in Basic mode because it assumes incorrect "dbo" schema

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -15,7 +15,7 @@ var debug = require('debug')('loopback:connector:mssql');
 
 mssql.map.register(Number, mssql.BigInt);
 
-var name = 'mssql';
+var name = 'powwow-loopback-connector-mssql';
 
 exports.name = name;
 exports.initialize = function initializeSchema(dataSource, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-mssql",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Microsoft SQL Server connector for LoopBack",
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Jira issue: https://powwowmobile.atlassian.net/browse/STUDIO-4397

Changes:
- updated connector name to fix issue with the incorrect selection of DB schema

Related pull requests: https://github.com/powwowinc/PowwowDesigner/pull/510, https://github.com/powwowinc/smartux-connect/pull/21